### PR TITLE
ci: add auto-merge workflow for dependency PRs

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -1,0 +1,26 @@
+name: Auto-merge dependency PRs
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]'
+    steps:
+      - name: Approve PR
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr review --approve "$PR_URL"
+
+      - name: Enable auto-merge
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --rebase "$PR_URL"


### PR DESCRIPTION
## Summary
- Add auto-merge workflow for dependency PRs from Dependabot and Renovate

## Changes
- Created `.github/workflows/auto-merge-deps.yml` workflow
- Automatically approves and enables auto-merge for dependency PRs
- Uses rebase merge strategy

## Test plan
- Workflow will trigger on next Dependabot/Renovate PR
- Verify PR is auto-approved and auto-merge is enabled