### PR TITLE
fix: pin trivy-action by SHA to prevent supply chain attacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
           cache-from: type=gha
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ghcr.io/netresearch/docker-ftp-server:test
           format: 'sarif'


### PR DESCRIPTION
## Summary

- Pin `aquasecurity/trivy-action` from mutable tag reference (`@0.35.0`) to immutable commit SHA (`@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0`)
- All other actions in the workflow were already SHA-pinned; this was the only remaining tag reference

## Why

Git tags are mutable -- a repository maintainer (or attacker with write access) can move a tag to point at a different commit. This is exactly what happened in the [tj-actions/changed-files supply chain attack](https://github.com/advisories/GHSA-mrrh-fwg8-r2c5) (March 2025), where attackers rewrote tags to inject malicious code into CI pipelines.

SHA-pinning ensures the workflow always runs the exact verified code, regardless of tag mutations. The version comment (`# v0.35.0`) preserves readability for Dependabot/Renovate updates.

## Test plan

- [ ] CI workflow runs successfully with the SHA-pinned reference
- [ ] Trivy scan produces the same SARIF output as before