### PR TITLE
fix: harden GitHub Actions against supply chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run hadolint
-        uses: hadolint/hadolint-action@v3.3.0
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:
           dockerfile: Dockerfile
           ignore: DL3018

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -68,7 +68,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
 
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0.23.1
+        uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0.23.1
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: spdx-json


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references to immutable commit SHAs (prevents tag/branch force-push attacks)
- Add Dependabot configuration for automatic GitHub Actions version updates

## Context

On 2026-03-19, `aquasecurity/trivy-action` was compromised via a tag force-push attack that exfiltrated secrets from CI runners. SHA-pinning prevents this class of attack entirely.

The netresearch org now enforces `sha_pinning_required=true` — workflows using tag/branch references will fail.

Ref: https://github.com/netresearch/ofelia/issues/535

## Test plan

- [ ] Verify CI passes with SHA-pinned actions
- [ ] Verify Dependabot creates PRs for action updates